### PR TITLE
Fixes prepending namespace slashs on class names

### DIFF
--- a/inc/database/class-database-processor.php
+++ b/inc/database/class-database-processor.php
@@ -69,7 +69,7 @@ abstract class Database_Processor extends \TMSC\Database\Processor {
 	}
 
 	/**
-	 * A helper function to fetch a custom set of results outside of the processors main migratables.
+	 * A helper function to fetch a custom set of results outside of the processors main migrateables.
 	 * @param string $stmt. An sql statement.
 	 * @param string $query_key. The key uses in $this->queries
 	 * @param array $params. Params to pass to query.

--- a/inc/database/class-migrateable.php
+++ b/inc/database/class-migrateable.php
@@ -51,7 +51,7 @@ abstract class Migrateable {
 	public $type;
 
 	/**
-	 * ID mapping for migratable type.
+	 * ID mapping for migrateable type.
 	 * @var array.
 	 */
 	public $id = array(
@@ -177,7 +177,7 @@ abstract class Migrateable {
 	}
 
 	/**
-	 * Save children migratables
+	 * Save children migrateables
 	 */
 	public function migrate_children(){
 		return true;

--- a/inc/database/class-processor.php
+++ b/inc/database/class-processor.php
@@ -25,10 +25,10 @@ abstract class Processor {
 	protected $data = array();
 
 	/**
-	 * The current migratable
+	 * The current migrateable
 	 * @var array
 	 */
-	public $migratable;
+	public $migrateable;
 
 
 	private $stop_processing = false;

--- a/inc/database/class-tmsc-media.php
+++ b/inc/database/class-tmsc-media.php
@@ -143,7 +143,7 @@ class TMSC_Media extends \TMSC\Database\Migrateable {
 		if ( ! empty( $legacy_id ) || '0' === $legacy_id ) {
 			$existing_post = tmsc_get_object_by_legacy_id( $legacy_id, $this->get_post_type() );
 			if ( ! empty( $existing_post ) ) {
-				if ( $existing_post instanceof WP_Post ) {
+				if ( $existing_post instanceof \WP_Post ) {
 					$this->object = $existing_post;
 				} elseif ( is_array( $existing_post ) ) {
 					global $_wp_suspend_cache_invalidation;

--- a/inc/database/class-tmsc-object.php
+++ b/inc/database/class-tmsc-object.php
@@ -14,7 +14,7 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 	public $type = 'post';
 
 	/**
-	 * The post type used with this migratable.
+	 * The post type used with this migrateable.
 	 */
 	public $post_type = '';
 
@@ -61,7 +61,7 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 	 * Get excerpt
 	 * @return html
 	 */
-	public function get_excerpt(){
+	public function get_excerpt() {
 		$default = ( ! empty( $this->object ) ) ? $this->object->post_excerpt : '';
 		return apply_filters( "tmsc_set_{$this->name}_excerpt", $default, $this->raw );
 	}
@@ -70,7 +70,7 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 	 * Get title
 	 * @return string
 	 */
-	public function get_title(){
+	public function get_title() {
 		$default = ( ! empty( $this->object ) ) ? $this->object->post_title : '';
 		$title = ( ! empty( $this->raw->Title ) ) ? $this->raw->Title : $default;
 		return apply_filters( "tmsc_set_{$this->name}_title", $title, $this->raw );
@@ -173,7 +173,7 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 		if ( ! empty( $legacy_id ) || '0' === $legacy_id ) {
 			$existing_post = tmsc_get_object_by_legacy_id( $legacy_id, $this->get_post_type() );
 			if ( ! empty( $existing_post ) ) {
-				if ( $existing_post instanceof WP_Post ) {
+				if ( $existing_post instanceof \WP_Post ) {
 					$this->object = $existing_post;
 				} elseif ( is_array( $existing_post ) ) {
 					// Our data is dirty. Wipe the duplicates and don't set an object.
@@ -305,7 +305,7 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 			$relationships = apply_filters( "tmsc_{$this->processor->processor_type}_relationship_map", array() );
 			$related_ids = array();
 			foreach ( $relationships as $key => $config ) {
-				// Store with migratable type as key.
+				// Store with migrateable type as key.
 				$related_ids[ $key ] = $this->processor->get_related( $this->raw->ID, $key, $config );
 			}
 			if ( ! empty( $related_ids ) ) {
@@ -321,20 +321,20 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 		$this->children['Media'] = null;
 		if ( ! empty( $this->object->ID ) && ! empty( $this->raw->ID ) ) {
 			$this->raw->wp_parent_id = $this->object->ID;
-			// Store with migratable type as key.
+			// Store with migrateable type as key.
 			$this->children['Media'] = $this->raw;
 		}
 	}
 
 	/**
-	 * Save children migratables
-	 * This migratable expects objects and media as children.
+	 * Save children migrateables
+	 * This migrateable expects objects and media as children.
 	 */
 	public function migrate_children(){
 		if ( ! empty( $this->children ) ) {
-			foreach( $this->children as $migratable_type => $raw_data ) {
+			foreach( $this->children as $migrateable_type => $raw_data ) {
 				if ( ! empty( $raw_data ) ) {
-					$child_processor = \TMSC\TMSC::instance()->get_processor( $migratable_type );
+					$child_processor = \TMSC\TMSC::instance()->get_processor( $migrateable_type );
 					$child_processor->set_parent_object( $raw_data );
 
 					if ( ! empty( $child_processor->get_object_query_stmt() ) ) {

--- a/inc/database/class-tmsc-object.php
+++ b/inc/database/class-tmsc-object.php
@@ -90,8 +90,8 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 	 * Get date of publication
 	 * @return int unix timestamp
 	 */
-	public function get_pubdate(){
-		$default = ( ! empty( $this->object ) && (int) date('Y', strtotime( $this->object->post_date ) ) > 1970 ) ? $this->object->post_date : current_time( 'Y-m-d H:i:s' );
+	public function get_pubdate() {
+		$default = ( ! empty( $this->object ) && (int) date( 'Y', strtotime( $this->object->post_date ) ) > 1970 ) ? $this->object->post_date : current_time( 'Y-m-d H:i:s' );
 		return apply_filters( "tmsc_set_{$this->name}_pubdate", $default, $this->raw );
 	}
 
@@ -99,7 +99,7 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 	 * Get body
 	 * @return HTML
 	 */
-	public function get_body(){
+	public function get_body() {
 		$default = ( ! empty( $this->object ) ) ? $this->object->post_content : '';
 		$decription = ( ! empty( $this->raw->Description ) ) ? $this->raw->Description : '';
 		$content = apply_filters( "tmsc_set_{$this->name}_body", $decription, $default, $this->raw );
@@ -330,9 +330,9 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 	 * Save children migrateables
 	 * This migrateable expects objects and media as children.
 	 */
-	public function migrate_children(){
+	public function migrate_children() {
 		if ( ! empty( $this->children ) ) {
-			foreach( $this->children as $migrateable_type => $raw_data ) {
+			foreach ( $this->children as $migrateable_type => $raw_data ) {
 				if ( ! empty( $raw_data ) ) {
 					$child_processor = \TMSC\TMSC::instance()->get_processor( $migrateable_type );
 					$child_processor->set_parent_object( $raw_data );

--- a/inc/database/class-tmsc-processor.php
+++ b/inc/database/class-tmsc-processor.php
@@ -33,7 +33,7 @@ abstract class TMSC_Processor extends \TMSC\Database\System_Processor {
 	}
 
 	/**
-	 * Get the next batch of migratables.
+	 * Get the next batch of migrateables.
 	 */
 	protected function before_run( $params = array() ) {
 		$stmt = $this->get_object_query_stmt();

--- a/inc/database/class-tmsc-taxonomy.php
+++ b/inc/database/class-tmsc-taxonomy.php
@@ -71,7 +71,7 @@ class TMSC_Taxonomy extends \TMSC\Database\Migrateable {
 		if ( ( ! empty( $legacy_id ) || '0' === $legacy_id ) && ! empty( $this->taxonomy ) ) {
 			$existing_term = tmsc_get_term_by_legacy_id( $legacy_id, $this->taxonomy );
 			if ( ! empty( $existing_term ) ) {
-				if ( $existing_term instanceof WP_Term ) {
+				if ( $existing_term instanceof \WP_Term ) {
 					$this->object = $existing_term;
 					if ( ! empty( $this->raw->Children ) && ! empty( $this->raw->CN ) ) {
 						$this->parents[ $this->raw->CN ] = $this->object->term_id;

--- a/inc/database/processors/tmsconnect/class-tmsconnect-constituent-processor.php
+++ b/inc/database/processors/tmsconnect/class-tmsconnect-constituent-processor.php
@@ -5,7 +5,7 @@
 namespace TMSC\Database\Processors\TMSConnect;
 class TMSConnect_Constituent_Processor extends \TMSC\Database\TMSC_Processor {
 	/**
-	 * Which migratable type the objects of this processor will be.
+	 * Which migrateable type the objects of this processor will be.
 	 */
 	public $migrateable_type = 'Object';
 
@@ -140,7 +140,7 @@ class TMSConnect_Constituent_Processor extends \TMSC\Database\TMSC_Processor {
 					$existing_term = tmsc_get_term_by_legacy_id( $row->TermID );
 
 					if ( ! empty( $existing_term ) && ! is_wp_error( $existing_term ) ) {
-						if ( $existing_term instanceof WP_Term ) {
+						if ( $existing_term instanceof \WP_Term ) {
 							$terms[ $existing_term->taxonomy ][] = $existing_term->term_id;
 						} elseif ( is_array( $existing_term ) ) {
 							// This will get triggered with search terms. So let's index both.

--- a/inc/database/processors/tmsconnect/class-tmsconnect-exhibition-processor.php
+++ b/inc/database/processors/tmsconnect/class-tmsconnect-exhibition-processor.php
@@ -5,7 +5,7 @@
 namespace TMSC\Database\Processors\TMSConnect;
 class TMSConnect_Exhibition_Processor extends \TMSC\Database\TMSC_Processor {
 	/**
-	 * Which migratable type the objects of this processor will be.
+	 * Which migrateable type the objects of this processor will be.
 	 */
 	public $migrateable_type = 'Object';
 
@@ -74,7 +74,7 @@ class TMSConnect_Exhibition_Processor extends \TMSC\Database\TMSC_Processor {
 					$existing_term = tmsc_get_term_by_legacy_id( $row->TermID );
 
 					if ( ! empty( $existing_term ) && ! is_wp_error( $existing_term ) ) {
-						if ( $existing_term instanceof WP_Term ) {
+						if ( $existing_term instanceof \WP_Term ) {
 							$terms[ $existing_term->taxonomy ][] = $existing_term->term_id;
 						} elseif ( is_array( $existing_term ) ) {
 							// This will get triggered with search terms. So let's index both.

--- a/inc/database/processors/tmsconnect/class-tmsconnect-media-processor.php
+++ b/inc/database/processors/tmsconnect/class-tmsconnect-media-processor.php
@@ -5,7 +5,7 @@
 namespace TMSC\Database\Processors\TMSConnect;
 class TMSConnect_Media_Processor extends \TMSC\Database\TMSC_Processor {
 	/**
-	 * Which migratable type the objects of this processor will be.
+	 * Which migrateable type the objects of this processor will be.
 	 */
 	public $migrateable_type = 'Media';
 
@@ -50,7 +50,7 @@ class TMSConnect_Media_Processor extends \TMSC\Database\TMSC_Processor {
 	}
 
 	/**
-	 * make sure we know the parent object of this migratable media.
+	 * make sure we know the parent object of this migrateable media.
 	 */
 	public function set_parent_object( $object ) {
 		$this->parent_object = $object;

--- a/inc/database/processors/tmsconnect/class-tmsconnect-object-processor.php
+++ b/inc/database/processors/tmsconnect/class-tmsconnect-object-processor.php
@@ -5,7 +5,7 @@
 namespace TMSC\Database\Processors\TMSConnect;
 class TMSConnect_Object_Processor extends \TMSC\Database\TMSC_Processor {
 	/**
-	 * Which migratable type the objects of this processor will be.
+	 * Which migrateable type the objects of this processor will be.
 	 */
 	public $migrateable_type = 'Object';
 
@@ -71,7 +71,7 @@ class TMSConnect_Object_Processor extends \TMSC\Database\TMSC_Processor {
 					$existing_term = tmsc_get_term_by_legacy_id( $row->TermID );
 
 					if ( ! empty( $existing_term ) && ! is_wp_error( $existing_term ) ) {
-						if ( $existing_term instanceof WP_Term ) {
+						if ( $existing_term instanceof \WP_Term ) {
 							$terms[ $existing_term->taxonomy ][] = $existing_term->term_id;
 						} elseif ( is_array( $existing_term ) ) {
 							// This will get triggered with search terms. So let's index both.

--- a/inc/database/processors/tmsconnect/class-tmsconnect-taxonomy-processor.php
+++ b/inc/database/processors/tmsconnect/class-tmsconnect-taxonomy-processor.php
@@ -2,7 +2,7 @@
 namespace TMSC\Database\Processors\TMSConnect;
 class TMSConnect_Taxonomy_Processor extends \TMSC\Database\TMSC_Processor {
 	/**
-	 * Which migratable type the objects of this processor will be.
+	 * Which migrateable type the objects of this processor will be.
 	 */
 	public $migrateable_type = 'Taxonomy';
 
@@ -30,7 +30,7 @@ class TMSConnect_Taxonomy_Processor extends \TMSC\Database\TMSC_Processor {
 	 */
 	public function __construct( $type ) {
 		parent::__construct( $type );
-		$this->taxonomies = $this->get_migratable_taxonomies();
+		$this->taxonomies = $this->get_migrateable_taxonomies();
 	}
 
 	/**
@@ -96,7 +96,7 @@ class TMSConnect_Taxonomy_Processor extends \TMSC\Database\TMSC_Processor {
 	/**
 	 * Get the taxonomies that we will be migrating.
 	 */
-	public function get_migratable_taxonomies() {
+	public function get_migrateable_taxonomies() {
 		$guide_terms = apply_filters( "tmsc_{$this->processor_type}_guide_terms", get_option( 'tmsc_guide_terms', array() ) );
 		$cns = array();
 		if ( ! empty( $guide_terms ) && ! empty( $guide_terms['term']['data'] ) ) {

--- a/inc/database/processors/tmsconnect/class-tmsconnect-zone-processor.php
+++ b/inc/database/processors/tmsconnect/class-tmsconnect-zone-processor.php
@@ -2,7 +2,7 @@
 namespace TMSC\Database\Processors\TMSConnect;
 class TMSConnect_Zone_Processor extends \TMSC\Database\TMSC_Processor {
 	/**
-	 * Which migratable type the objects of this processor will be.
+	 * Which migrateable type the objects of this processor will be.
 	 */
 	public $migrateable_type = 'Zone';
 

--- a/inc/helper-functions.php
+++ b/inc/helper-functions.php
@@ -86,7 +86,7 @@ function tmsc_get_linked_objects( int $post_id, $taxonomy ) {
 				$linked_post = tmsc_get_linked_post( $term->term_id );
 
 				// Add it to the linked objects.
-				if ( $linked_post instanceof WP_Post ) {
+				if ( $linked_post instanceof \WP_Post ) {
 					$linked_objects[] = $linked_post;
 				}
 			}
@@ -131,7 +131,7 @@ function tmsc_get_image_public_caption( $attachment_id ) : string {
 	$attachment = get_post( $attachment_id );
 
 	// The public image caption is saved as post content.
-	if ( $attachment instanceof WP_Post ) {
+	if ( $attachment instanceof \WP_Post ) {
 		return $attachment->post_content;
 	}
 

--- a/tmsconnect.php
+++ b/tmsconnect.php
@@ -23,7 +23,7 @@ require_once( TMSCONNECT_PATH . '/inc/trait-singleton.php' );
 
 /**
  * Return an array of all the processors of the current system.
- * Each processor requires a it's own migratable class and a processor class.
+ * Each processor requires a it's own migrateable class and a processor class.
  * (e.g.) "class-${file_prefix}-${processor}.php", "class-${file_prefix}-${processor}-processor.php"
  * @return array.
  */


### PR DESCRIPTION
Also a few `migratable` -> `migrateable` typos