### PR TITLE
Remove default content value and always use the filtered value.

### DIFF
--- a/inc/database/class-tmsc-object.php
+++ b/inc/database/class-tmsc-object.php
@@ -100,10 +100,9 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 	 * @return HTML
 	 */
 	public function get_body() {
-		$default = ( ! empty( $this->object ) ) ? $this->object->post_content : '';
 		$decription = ( ! empty( $this->raw->Description ) ) ? $this->raw->Description : '';
-		$content = apply_filters( "tmsc_set_{$this->name}_body", $decription, $default, $this->raw );
-		return ( empty( $content ) ) ? $default : $content;
+		$content = apply_filters( "tmsc_set_{$this->name}_body", $decription, $this->raw );
+		return $content;
 	}
 
 	/**


### PR DESCRIPTION
This will remove the `default` value and always force the object sync to use the value provided by the payload (or the filter). This fixes a bug where an _existing_ object description was not being overwritten with an empty value if the source data removed the description intentionally.