### PR TITLE
Fix object migration issue - objects syncing all the times whether it's already in sync

### DIFF
--- a/inc/database/class-tmsc-object.php
+++ b/inc/database/class-tmsc-object.php
@@ -174,6 +174,12 @@ class TMSC_Object extends \TMSC\Database\Migrateable {
 			if ( ! empty( $existing_post ) ) {
 				if ( $existing_post instanceof \WP_Post ) {
 					$this->object = $existing_post;
+
+					// This requires is requires in while comparing raw hash for object,
+					// as `wp_parent_id` property is adding in `save_media_attachments()`
+					// which is storing as hash code of $this->raw object.
+					$this->raw->wp_parent_id = $this->object->ID;
+
 				} elseif ( is_array( $existing_post ) ) {
 					// Our data is dirty. Wipe the duplicates and don't set an object.
 					global $_wp_suspend_cache_invalidation;


### PR DESCRIPTION
Found one issue here, when we migrate objects it is saving `wp_parent_id` property as part of a hash code of `$this-raw` object and that property is added in `save_media_attachments()` function available in `tmsconnect/inc/database/class-tmsc-object.php`. At the time of re-migrating that object is not loading `wp_parent_id` property for `$this->raw` object which is making all objects sync all the times because the hash codes are different here, one is with `wp_parent_id` property and another one is without that.

Let me know if more details needed here. Thanks!