### PR TITLE
Fix for Constituent sync

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -54,8 +54,7 @@ function tmsc_update_cursor( $processor, $batch_size = 0, $completed = false ) {
  * @return string
  */
 function tmsc_hash_data( $data ) {
-	$serialize = function_exists( 'igbinary_serialize' ) ? 'igbinary_serialize' : 'serialize';
-	return md5( $serialize( $data ) );
+	return md5( serialize( $data ) );
 }
 
 /**

--- a/inc/class-tmsc-cli-command.php
+++ b/inc/class-tmsc-cli-command.php
@@ -98,7 +98,6 @@ class TMSC_CLI_Command extends WP_CLI_Command {
 				$cursor = tmsc_get_cursor( $processor_slug );
 				do {
 					if ( empty( $cursor['completed'] ) ) {
-						wp_mail( 'spencer@automattic.com', '[TMSC Sync Running Batch]', "Processing {$processor_slug} with offset {$cursor['offset']}" );	
 						if( defined( 'WP_CLI' ) && WP_CLI ) {
 							WP_CLI::line( "Processing {$processor_slug} with offset {$cursor['offset']}" );
 						}
@@ -115,11 +114,6 @@ class TMSC_CLI_Command extends WP_CLI_Command {
 								$cursor['offset']
 							) );
 						}
-						wp_mail( 'spencer@automattic.com', '[TMSC Sync Completed Processor]', sprintf(
-                                                        __( "Sync for %s Processor Complete!\n%d\tfinal offset", 'tmsc' ),
-                                                        $processor_class_slug,
-                                                        $cursor['offset']
-                                                ));
 						$doing_migration = false;
 					}
 					$this->contain_memory_leaks();
@@ -143,7 +137,6 @@ class TMSC_CLI_Command extends WP_CLI_Command {
 		}
 
 		$this->finish( $timestamp_start );
-		wp_mail( 'spencer@automattic.com', '[TMSC Sync Complete!]', 'Done!' );
 		return true;
 	}
 

--- a/inc/class-tmsc-sync.php
+++ b/inc/class-tmsc-sync.php
@@ -183,7 +183,6 @@ class TMSC_Sync {
 			wp_clear_scheduled_hook( 'tmsc_actually_sync_objects' );
 			wp_schedule_single_event( time(), 'tmsc_actually_sync_objects', array() );
 			update_option( 'tmsc-sync-complete', false );
-			wp_mail( 'spencer@automattic.com', '[TMSC Sync Queued]', 'Queued' );
 
 			// If we pressed the button manually, process any post processing data.
 			if ( '1' === self::$enable_cron ) {
@@ -222,7 +221,6 @@ class TMSC_Sync {
 			$previous_sync_state['sync_message_unchanged_count'] = 0;
 		}
 
-		wp_mail( 'spencer@automattic.com', '[Sync Monitor has just run]', var_export( $previous_sync_state, true ) );
 		update_option( 'tmsc_current_sync_state', $previous_sync_state );
 	}
 
@@ -235,8 +233,6 @@ class TMSC_Sync {
                 $assoc_args = array(
                         'batch_size' => 10,
                 );
-
-		wp_mail( 'spencer@automattic.com', '[TMSC Sync Attempting Batch]', var_export( $completed, true ) );
 
 		if ( ! empty( $assoc_args['reset'] ) ) {
 			$this->reset();
@@ -280,7 +276,6 @@ class TMSC_Sync {
 				$cursor = tmsc_get_cursor( $processor_slug );
 				do {
 					if ( empty( $cursor['completed'] ) ) {
-						wp_mail( 'spencer@automattic.com', '[TMSC Sync Running Batch]', "Processing {$processor_slug} with offset {$cursor['offset']}" );	
 						tmsc_set_sync_status( "Processing {$processor_slug} with offset {$cursor['offset']}" );
 
 						$doing_migration = true;
@@ -288,15 +283,9 @@ class TMSC_Sync {
 						$cursor = tmsc_get_cursor( $processor_slug );
 						
 						// Only process one batch at a time. Requeue this job and bail.
-						wp_mail( 'spencer@automattic.com', '[TMSC Sync Requeued]', 'Requeued' );
 						wp_schedule_single_event( time(), 'tmsc_actually_sync_objects' );
 						return;
 					} else {
-						wp_mail( 'spencer@automattic.com', '[TMSC Sync Completed Processor]', sprintf(
-                                                        __( "Sync for %s Processor Complete!\n%d\tfinal offset", 'tmsc' ),
-                                                        $processor_class_slug,
-                                                        $cursor['offset']
-                                                ));
 						$doing_migration = false;
 					}
 				} while ( $doing_migration );
@@ -306,8 +295,6 @@ class TMSC_Sync {
 		}
 
 		\TMSC\TMSC_Sync::instance()->complete_sync();
-
-		wp_mail( 'spencer@automattic.com', '[TMSC Sync Complete!]', 'Done!' );
 	}
 
 	
@@ -576,7 +563,6 @@ class TMSC_Sync {
 
 				// Only process one batch at a time. Requeue the cron job to run again.
 				//$post_processing_data = false;	
-				wp_mail( 'spencer@automattic.com', '[TMSC Sync Running Batch]', "Doing post processing. Batch #$batch_number." );	
 				tmsc_set_sync_status( "Doing post processing. Batch #$batch_number." );
 			} while ( ! empty( $post_processing_data ) );
 

--- a/inc/class-tmsc-sync.php
+++ b/inc/class-tmsc-sync.php
@@ -96,6 +96,48 @@ class TMSC_Sync {
 			add_action( 'wp_ajax_sync_objects', array( self::$instance, 'sync_objects' ) );
 			add_action( 'wp_ajax_get_option_value', array( self::$instance, 'ajax_get_option_value' ) );
 		}
+
+		add_action( 'rest_api_init', array( self::$instance, 'create_rest_endpoints' ) );
+	}
+
+	public function create_rest_endpoints() {
+		\register_rest_route( 'tmsc/v1', '/sync/', array(
+			'methods' => 'POST',
+			'callback' => array( self::$instance, 'sync_objects' ),
+			'permission_callback' => array( self::$instance, 'authorize_rest_request' ),
+		) );
+
+		\register_rest_route( 'tmsc/v1', '/sync-status/', array(
+			'methods' => 'POST',
+			'callback' => array( self::$instance, 'ajax_get_option_value' ),
+			'permission_callback' => array( self::$instance, 'authorize_rest_request' ),
+		) );
+
+		\register_rest_route( 'tmsc/v1', '/sync-nonce/', array(
+			'methods' => 'POST',
+			'callback' => array( self::$instance, 'get_sync_nonce' ),
+			'permission_callback' => array( self::$instance, 'authorize_rest_request' ),
+		) );
+
+		\register_rest_route( 'tmsc/v1', '/status-nonce/', array(
+			'methods' => 'POST',
+			'callback' => array( self::$instance, 'get_status_nonce' ),
+			'permission_callback' => array( self::$instance, 'authorize_rest_request' ),
+		) );
+	}
+
+	public function authorize_rest_request() {
+		return current_user_can('edit_pages');
+	}
+
+	public function get_sync_nonce() {
+		\wp_send_json_success( array( 'nonce' => \wp_create_nonce( 'tmsc_object_sync' ) ) );
+		exit();
+	}
+
+	public function get_status_nonce() {
+		\wp_send_json_success( array( 'nonce' => \wp_create_nonce( 'wp_admin_js_script' ) ) );
+		exit();
 	}
 
 	/**

--- a/inc/class-tmsc-sync.php
+++ b/inc/class-tmsc-sync.php
@@ -231,7 +231,7 @@ class TMSC_Sync {
                 );
 
                 $assoc_args = array(
-                        'batch_size' => 10,
+                        'batch_size' => 200,
                 );
 
 		if ( ! empty( $assoc_args['reset'] ) ) {

--- a/inc/class-tmsc-sync.php
+++ b/inc/class-tmsc-sync.php
@@ -268,13 +268,18 @@ class TMSC_Sync {
 
 	public function actually_sync_objects() {
 		$args = array(
-                        'taxonomy',
-                        'object',
-                );
+			'taxonomy',
+			'object',
+		);
 
-                $assoc_args = array(
-                        'batch_size' => 200,
-                );
+		$processors_cursor = get_option( 'tmsc-processors-cursor' );
+		if ( ! empty( $processors_cursor ) ) {
+			$args = array_keys( $processors_cursor );
+		}
+
+		$assoc_args = array(
+			'batch_size' => 200,
+		);
 
 		if ( ! empty( $assoc_args['reset'] ) ) {
 			$this->reset();

--- a/inc/class-tmsc.php
+++ b/inc/class-tmsc.php
@@ -185,6 +185,8 @@ class TMSC {
 	public function migrate( $processor_class_slug, $assc_args = array() ) {
 		if ( ! defined( 'WP_IMPORTING' ) ) {
 			define( 'WP_IMPORTING', true );
+			define( 'TMSC_IMPORTING', true );
+			define( 'DOING_CRON', true );
 		}
 
 		/**

--- a/js/tmsc-admin-sync.js
+++ b/js/tmsc-admin-sync.js
@@ -28,8 +28,8 @@ jQuery(document).ready(($) => {
    */
   function setUIVisibility() {
     if ('Syncing TMS Objects' === updatedTime.val()) {
-      objectSyncButton.hide();
-      updatedTxt.hide();
+      //objectSyncButton.hide();
+      //updatedTxt.hide();
       loadingImg.attr('style', 'visibility:visible');
       setTimeout(pollSyncStatus, 5000);
     } else {

--- a/tmsconnect.php
+++ b/tmsconnect.php
@@ -135,7 +135,6 @@ function tmsc_dependency() {
 		new \TMSC\Plugin_Dependency( 'TMS Connect', 'Fieldmanager', 'https://github.com/alleyinteractive/wordpress-fieldmanager' ),
 		new \TMSC\Plugin_Dependency( 'TMS Connect', 'Zone Manager (Zoninator)', 'https://github.com/Automattic/zoninator' ),
 		new \TMSC\Plugin_Dependency( 'TMS Connect', 'Fieldmanager Zones', 'https://github.com/alleyinteractive/fm-zones' ),
-		new \TMSC\Plugin_Dependency( 'TMS Connect', 'SearchPress', 'https://github.com/alleyinteractive/searchpress' ),
 	);
 	foreach ( $tmsc_dependencies as $tmsc_dependency ) {
 		if ( ! $tmsc_dependency->verify() ) {


### PR DESCRIPTION
Request: https://github.com/a8cteam51/team51-dev-requests/issues/1372

> From the partner:
> 
> If I run the sync via this page, and I select only constituents, it will not sync.
> 
> https://asia.si.edu/wp-admin/edit.php?post_type=tms_object&page=tmsc-sync
> 
> but if I execute the wp-cli command line:
> 
> wp tmsconnect sync constituent --batch-size=200 --reset
> 
> the constituents will sync.
> 
> I thought the wp-admin page executes the same command as the command line.


The commit de714e1bb5b4d0067970daf8f965695a67f51915 fixes the problem by replacing `$args` with the processors already stored in the database, if any. What was happening is that `$args` was overwriting the database value with only Taxonomy and Object, leaving all the other selected processors out of the sync process.